### PR TITLE
Fix toast CSS import for Netlify builds

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,7 @@ import { Header } from '@/components/layout/header'
 import { Footer } from '@/components/layout/footer'
 import { WhatsAppButton } from '@/components/ui/whatsapp-button'
 import { Analytics } from '@/components/analytics'
-import { Toaster } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
+import { ToastProvider } from '@/components/providers/toast-provider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -86,18 +85,7 @@ export default function RootLayout({
         </main>
         <Footer />
         <WhatsAppButton />
-        <Toaster
-          position="top-right"
-          autoClose={5000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="light"
-        />
+        <ToastProvider />
         <Analytics />
       </body>
     </html>

--- a/components/providers/toast-provider.tsx
+++ b/components/providers/toast-provider.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+
+export function ToastProvider() {
+  return (
+    <ToastContainer
+      position="top-right"
+      autoClose={5000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="light"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- move the React Toastify container into a client-only provider
- import the toast CSS inside the client provider to avoid server build errors
- use the provider from the root layout instead of importing toast styles directly

## Testing
- npm run build *(fails: network restricted when fetching Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6710dac832fb41b7d017a41ee16